### PR TITLE
chore: specify engine versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,10 @@
         "tslib": "^2.6.2",
         "typescript": "^5.4.5",
         "vite": "^5.2.11"
+      },
+      "engines": {
+        "node": ">=18.13 <22.0.0",
+        "npm": ">=10.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "scec-frontend",
   "version": "0.0.1",
   "private": true,
+  "engines" : {
+    "npm" : ">=10.0",
+    "node" : ">=18.13 <22.0.0"
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
prevent using older versions of npm/node