### PR TITLE
chore: update dependencies - recharts to 3.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-loading-skeleton": "^3.5.0",
-        "recharts": "^3.8.0"
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -6427,9 +6427,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
-      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
       "license": "MIT",
       "workspaces": [
         "www"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-loading-skeleton": "^3.5.0",
-    "recharts": "^3.8.0"
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
## This PR contains updated dependencies:

| Package | Type | Update | Change |
|---------|------|--------|--------|
| recharts | npm | patch | `3.8.0` → `3.8.1` |

---

All updates have been tested and verified:

:white_check_mark: Build successful
<details><summary>Build logs</summary>

```
if you'd not like to participate in this anonymous program, by visiting the following URL:
https://nextjs.org/telemetry

▲ Next.js 16.2.1 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 5.3s
  Running TypeScript ...
  Finished TypeScript in 5.1s ...
  Collecting page data using 3 workers ...
  Generating static pages using 3 workers (0/11) ...
  Generating static pages using 3 workers (2/11) 
  Generating static pages using 3 workers (5/11) 
  Generating static pages using 3 workers (8/11) 
✓ Generating static pages using 3 workers (11/11) in 412ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /auth/forgot-password
├ ○ /auth/signup
├ ƒ /config
├ ○ /dashboard
├ ƒ /endpoint/[name]
├ ○ /endpoints
├ ƒ /healthz
├ ƒ /invitation/[name]
├ ○ /mitigations
├ ○ /profile
├ ƒ /release/[name]
├ ○ /releases
├ ○ /vulnerabilities
└ ƒ /vulnerability/[name]


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```

</details>

:rocket: **This PR is safe to merge.** All dependency updates have been verified with a successful build and passing tests.
